### PR TITLE
feat(home): ajouter le composant de la page d'accueil

### DIFF
--- a/src/app/visitors/home/home.page.component.html
+++ b/src/app/visitors/home/home.page.component.html
@@ -1,0 +1,11 @@
+<section id="about">
+  <app-about />
+</section>
+
+<section id="projects">
+  <app-projects />
+</section>
+
+<section id="contact">
+  <app-contact />
+</section>

--- a/src/app/visitors/home/home.page.component.spec.ts
+++ b/src/app/visitors/home/home.page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomePageComponent } from './home.page.component';
+
+describe('HomePageComponent', () => {
+  let component: HomePageComponent;
+  let fixture: ComponentFixture<HomePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePageComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/visitors/home/home.page.component.ts
+++ b/src/app/visitors/home/home.page.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { AboutDumbComponent } from './about/about.dumb.component';
+import { ProjectsDumbComponent } from './projects/projects.dumb.component';
+import { ContactDumbComponent } from './contact/contact.dumb.component';
+
+@Component({
+  imports: [AboutDumbComponent, ProjectsDumbComponent, ContactDumbComponent],
+  templateUrl: './home.page.component.html',
+  styleUrl: './home.page.component.scss'
+})
+export class HomePageComponent {}


### PR DESCRIPTION
Implémente la structure initiale du composant HomePage, incluant son template, son style et ses tests unitaires. Cette mise en place permet d'afficher les sections "about", "projects" et "contact".