### PR TITLE
feat(projects): ajouter le composant dumb Projects

### DIFF
--- a/src/app/visitors/home/projects/projects.dumb.component.html
+++ b/src/app/visitors/home/projects/projects.dumb.component.html
@@ -1,0 +1,1 @@
+<p>projects works!</p>

--- a/src/app/visitors/home/projects/projects.dumb.component.spec.ts
+++ b/src/app/visitors/home/projects/projects.dumb.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectsDumbComponent } from './projects.dumb.component';
+
+describe('ProjectsDumbComponent', () => {
+  let component: ProjectsDumbComponent;
+  let fixture: ComponentFixture<ProjectsDumbComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectsDumbComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectsDumbComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/visitors/home/projects/projects.dumb.component.ts
+++ b/src/app/visitors/home/projects/projects.dumb.component.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-projects',
+  imports: [],
+  templateUrl: './projects.dumb.component.html',
+  styleUrl: './projects.dumb.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ProjectsDumbComponent {}


### PR DESCRIPTION
- Création du composant `ProjectsDumbComponent` avec une stratégie de détection des changements `OnPush` pour des performances optimisées.
- Ajout d'un fichier HTML de base contenant un message par défaut ("projects works!").
- Ajout d'un fichier de styles SCSS (vide pour l'instant).
- Implémentation d'un test unitaire de base garantissant la création correcte du composant.
- Cette structure prépare le terrain pour le développement ultérieur des fonctionnalités de la section "Projects".