### PR TITLE
feat(visitors): ajouter le composant SkillsDumb

### DIFF
--- a/src/app/visitors/home/skills/skills.dumb.component.html
+++ b/src/app/visitors/home/skills/skills.dumb.component.html
@@ -1,0 +1,1 @@
+<p>skills works!</p>

--- a/src/app/visitors/home/skills/skills.dumb.component.spec.ts
+++ b/src/app/visitors/home/skills/skills.dumb.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillsDumbComponent } from './skills.dumb.component';
+
+describe('SkillsDumbComponent', () => {
+  let component: SkillsDumbComponent;
+  let fixture: ComponentFixture<SkillsDumbComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SkillsDumbComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkillsDumbComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/visitors/home/skills/skills.dumb.component.ts
+++ b/src/app/visitors/home/skills/skills.dumb.component.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-skills',
+  imports: [],
+  templateUrl: './skills.dumb.component.html',
+  styleUrl: './skills.dumb.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SkillsDumbComponent {}


### PR DESCRIPTION
- Création du composant `SkillsDumbComponent` avec Angular pour afficher les compétences de l'utilisateur.
- Ajout des fichiers associés : HTML, SCSS, TypeScript, et fichier de test unitaire.
- Adoption de la stratégie de détection de changement `OnPush` pour optimiser les performances.
- Inclusion d'un test unitaire pour certifier la création initiale du composant.