### PR TITLE
feat(shared): ajouter le composant bouton "dumb"

### DIFF
--- a/src/app/shared/components/button/button.dumb.component.html
+++ b/src/app/shared/components/button/button.dumb.component.html
@@ -1,0 +1,1 @@
+<p>button works!</p>

--- a/src/app/shared/components/button/button.dumb.component.spec.ts
+++ b/src/app/shared/components/button/button.dumb.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonDumbComponent } from './button.dumb.component';
+
+describe('ButtonDumbComponent', () => {
+  let component: ButtonDumbComponent;
+  let fixture: ComponentFixture<ButtonDumbComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ButtonDumbComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonDumbComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/button/button.dumb.component.ts
+++ b/src/app/shared/components/button/button.dumb.component.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  standalone: true,
+  imports: [],
+  templateUrl: './button.dumb.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [
+    `
+    <button
+      [type]="type()"
+      [disabled]="disabled()"
+      (click)="clicked.emit()"
+    >
+      {{ title() }}
+    </button>
+  `
+  ]
+})
+export class ButtonDumbComponent {
+  title = input.required<string>();
+  type = input.required<'button' | 'submit' | 'reset' | 'cancel'>();
+  disabled = input<boolean>(false);
+
+  clicked = output<void>();
+}


### PR DESCRIPTION
- Implémentation d'un composant "dumb" ButtonDumbComponent avec une détection de changement optimisée via OnPush.
- Ajout du HTML, SCSS et du support des tests basiques pour assurer la fonctionnalité.
- Introduction des entrées (title, type, disabled) et de la sortie (clicked) permettant une gestion configurable des boutons.
- Fournit une base réutilisable pour des boutons simples dans l'application.