### PR TITLE
chore(dashboard): remove Calendly component from admin dashboard

### DIFF
--- a/src/app/admin/dashboard/dashboard.page.component.html
+++ b/src/app/admin/dashboard/dashboard.page.component.html
@@ -1,7 +1,6 @@
 <div class="flex flex-col gap-4">
   <app-counters-dumb [counters]="countersService.getAllCounters()" />
   <app-charts-smart />
-  <app-calendly-smart />
   <app-about-smart />
   <app-projects />
 </div>

--- a/src/app/admin/dashboard/dashboard.page.component.ts
+++ b/src/app/admin/dashboard/dashboard.page.component.ts
@@ -1,7 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { Project } from '../../visitors/home/projects/models/project.model';
 import { AboutSmartComponent } from '../about/about.smart.component';
-import { CalendlySmartComponent } from '../calendly/calendly.smart.component';
 import { ProjectsSmartComponent } from '../projects/projects.smart.component';
 import { ChartsSmartComponent } from '../stats/charts/charts/charts.smart.component';
 import { CountersDumbComponent } from '../stats/counters/counters.dumb.component';
@@ -13,7 +12,6 @@ import { CountersService } from '../stats/counters/services/counters.service';
     ProjectsSmartComponent,
     CountersDumbComponent,
     ChartsSmartComponent,
-    CalendlySmartComponent,
     AboutSmartComponent
   ],
   templateUrl: './dashboard.page.component.html',


### PR DESCRIPTION
- Remove Calendly smart component import and usage
- Simplify dashboard layout by eliminating unused Calendly section
- Consistent with previous removal of Calendly admin configuration