### PR TITLE
chore(components): remove standalone decorator from multiple components

### DIFF
--- a/src/app/admin/about/about.smart.component.ts
+++ b/src/app/admin/about/about.smart.component.ts
@@ -7,7 +7,6 @@ import { AboutFormConfig } from './data/about-form.config';
 
 @Component({
   selector: 'app-about-smart',
-  standalone: true,
   imports: [ReactiveFormsModule, NgClass, CommonModule],
   templateUrl: './about.smart.component.html',
   styleUrl: './about.smart.component.scss',

--- a/src/app/admin/dashboard/dashboard.page.component.ts
+++ b/src/app/admin/dashboard/dashboard.page.component.ts
@@ -7,7 +7,6 @@ import { CountersDumbComponent } from '../stats/counters/counters.dumb.component
 import { CountersService } from '../stats/counters/services/counters.service';
 
 @Component({
-  standalone: true,
   imports: [
     ProjectsSmartComponent,
     CountersDumbComponent,

--- a/src/app/admin/projects/projects-list.component.ts
+++ b/src/app/admin/projects/projects-list.component.ts
@@ -4,7 +4,6 @@ import { Project } from './models/project.model';
 
 @Component({
   selector: 'app-projects-list',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <div class="bg-background/90 rounded-lg border border-tertiary/20">

--- a/src/app/admin/projects/projects.smart.component.ts
+++ b/src/app/admin/projects/projects.smart.component.ts
@@ -9,7 +9,6 @@ import { ProjectsListComponent } from './projects-list.component';
 
 @Component({
   selector: 'app-projects',
-  standalone: true,
   imports: [NgClass, ReactiveFormsModule, ProjectsListComponent],
   templateUrl: './projects.smart.component.html',
   styleUrl: './projects.smart.component.scss',

--- a/src/app/admin/stats/charts/charts/charts-filter.dumb.component.ts
+++ b/src/app/admin/stats/charts/charts/charts-filter.dumb.component.ts
@@ -26,8 +26,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
         hover:border-tertiary/40"
       />
     </div>
-  `,
-  standalone: true
+  `
 })
 export class ChartsFilterDumbComponent {
   private fb = inject(FormBuilder);

--- a/src/app/admin/stats/charts/charts/charts.dumb.component.ts
+++ b/src/app/admin/stats/charts/charts/charts.dumb.component.ts
@@ -4,7 +4,6 @@ import { BaseChartDirective } from 'ng2-charts';
 
 @Component({
   selector: 'app-charts-dumb',
-  standalone: true,
   imports: [BaseChartDirective],
   template: `
     <div class="w-full h-[400px]">

--- a/src/app/admin/stats/charts/charts/charts.smart.component.ts
+++ b/src/app/admin/stats/charts/charts/charts.smart.component.ts
@@ -5,7 +5,6 @@ import { ChartsDumbComponent } from './charts.dumb.component';
 
 @Component({
   selector: 'app-charts-smart',
-  standalone: true,
   imports: [ChartsDumbComponent, ChartsFilterDumbComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/src/app/admin/stats/counters/counters.dumb.component.ts
+++ b/src/app/admin/stats/counters/counters.dumb.component.ts
@@ -4,7 +4,6 @@ import { Counters } from './models/counters.model';
 
 @Component({
   selector: 'app-counters-dumb',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <div class="container mx-auto px-4 py-12">

--- a/src/app/auth/components/login/login.smart.component.ts
+++ b/src/app/auth/components/login/login.smart.component.ts
@@ -12,7 +12,6 @@ import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
-  standalone: true,
   imports: [NgClass, ReactiveFormsModule],
   templateUrl: './login.smart.component.html',
   styleUrl: './login.smart.component.scss',

--- a/src/app/shared/components/footer/footer.smart.component.ts
+++ b/src/app/shared/components/footer/footer.smart.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'app-footer',
-  standalone: true,
   templateUrl: './footer.smart.component.html',
   styleUrl: './footer.smart.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/components/toast/toast.smart.component.ts
+++ b/src/app/shared/components/toast/toast.smart.component.ts
@@ -10,7 +10,6 @@ import { ToastService } from './service/toast.service';
  */
 @Component({
   selector: 'app-toast',
-  standalone: true,
   imports: [CommonModule],
   template: `
     @if (visible) {

--- a/src/app/visitors/home/about/about.dumb.component.ts
+++ b/src/app/visitors/home/about/about.dumb.component.ts
@@ -5,7 +5,6 @@ import { ButtonDumbComponent } from '../../../shared/components/button/button.du
 
 @Component({
   selector: 'app-about-dumb',
-  standalone: true,
   imports: [CommonModule, ButtonDumbComponent],
   templateUrl: './about.dumb.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/visitors/home/contact/contact.dumb.component.ts
+++ b/src/app/visitors/home/contact/contact.dumb.component.ts
@@ -4,7 +4,6 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 
 @Component({
   selector: 'app-contact',
-  standalone: true,
   imports: [ReactiveFormsModule, NgClass],
   templateUrl: './contact.dumb.component.html',
   styleUrl: './contact.dumb.component.scss',

--- a/src/app/visitors/home/home.page.component.ts
+++ b/src/app/visitors/home/home.page.component.ts
@@ -6,7 +6,6 @@ import { ProjectsDumbComponent } from './projects/projects.dumb.component';
 import { SkillsDumbComponent } from './skills/skills.dumb.component';
 
 @Component({
-  standalone: true,
   imports: [AboutDumbComponent, ProjectsDumbComponent, ContactDumbComponent, SkillsDumbComponent],
   templateUrl: './home.page.component.html',
   styleUrl: './home.page.component.scss'

--- a/src/app/visitors/home/projects/projects.dumb.component.ts
+++ b/src/app/visitors/home/projects/projects.dumb.component.ts
@@ -16,7 +16,6 @@ import { ProjectsService } from '../../../core/services/projects.service';
 // Décorateur du composant avec ses métadonnées
 @Component({
   selector: 'app-projects', // Sélecteur utilisé pour intégrer le composant
-  standalone: true, // Composant autonome (nouvelle fonctionnalité Angular)
   imports: [NgOptimizedImage, ReactiveFormsModule], // Modules importés localement
   templateUrl: './projects.dumb.component.html', // Template HTML associé
   styleUrl: './projects.dumb.component.scss', // Styles SCSS associés


### PR DESCRIPTION
Remove `standalone: true` decorator from various components across different modules to standardize component configuration