### PR TITLE
chore(typescript): add Node.js types to TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "types": ["node"]
   },
   "angularCompilerOptions": {
     "extendedDiagnostics": {


### PR DESCRIPTION
- Include `@types/node` in tsconfig.json
- Improve type definitions for Node.js-related development