### PR TITLE
chore(typescript): add Jest types to TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "angularCompilerOptions": {
     "extendedDiagnostics": {


### PR DESCRIPTION
- Include `@types/jest` in tsconfig.json
- Improve type definitions for testing with Jest