### PR TITLE
chore(docker): adjust Nginx static file deployment path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN npm run build -- --configuration production
 FROM nginx:alpine
 
 # Crée le répertoire pour les fichiers statiques
-RUN mkdir -p /usr/share/nginx/html/browser
+RUN mkdir -p /usr/share/nginx/html/
 
 # Copie les fichiers buildés depuis l'étape de build
-COPY --from=build /app/dist/app-graduate-portfolio/. /usr/share/nginx/html/browser
+COPY --from=build /app/dist/app-graduate-portfolio/ /usr/share/nginx/html/
 
 EXPOSE 80
 


### PR DESCRIPTION
- Simplify Dockerfile static file copy strategy
- Remove 'browser' subdirectory in Nginx serving path
- Ensure direct deployment of Angular SSR build artifacts