### PR TITLE
feat(stats): gérer les erreurs de récupération des visites en temps réel

### DIFF
--- a/src/app/admin/stats/charts/charts/charts.smart.component.ts
+++ b/src/app/admin/stats/charts/charts/charts.smart.component.ts
@@ -31,6 +31,7 @@ export class ChartsSmartComponent {
     // Initialiser les données au démarrage
     this.statsService.getStats('week', new Date()).subscribe();
     this.statsService.getRealTimeVisits().subscribe((visits) => {
+      this.realTimeVisits = visits;
       console.log('Nombre de visites en temps réel:', visits);
       // Vous pouvez également mettre à jour une propriété pour afficher cela dans le template
     });

--- a/src/app/admin/stats/services/stats.service.ts
+++ b/src/app/admin/stats/services/stats.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, computed, inject, signal } from '@angular/core';
-import { Observable, tap } from 'rxjs';
+import { Observable, catchError, of, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment.development';
 import { VisitStats } from '../models/visit.model';
 
@@ -89,6 +89,11 @@ export class StatsService {
   }
 
   getRealTimeVisits(): Observable<number> {
-    return this.http.get<number>(`${this.API_URL}/real-time-visits`);
+    return this.http.get<number>(`${this.API_URL}/real-time-visits`).pipe(
+      catchError((error) => {
+        console.error('Erreur lors de la récupération des visites en temps réel:', error);
+        return of(0); // Retourne 0 ou une valeur par défaut en cas d'erreur
+      })
+    );
   }
 }


### PR DESCRIPTION
- Ajouter une gestion d'erreur dans getRealTimeVisits() du StatsService
- Initialiser la propriété realTimeVisits dans le composant de charts
- Fournir une valeur par défaut (0) en cas d'échec de la requête HTTP