### PR TITLE
feat(stats): ajouter le compteur de visites LinkedIn

### DIFF
--- a/src/app/admin/stats/counters/counters.dumb.component.ts
+++ b/src/app/admin/stats/counters/counters.dumb.component.ts
@@ -55,6 +55,21 @@ import { Counters } from './models/counters.model';
             <span class="text-text text-sm">Visites GitHub</span>
           </div>
         </div>
+        <div
+          class="p-6 rounded-lg bg-background/90 backdrop-blur-md border-2 border-tertiary/20 shadow-lg transform hover:-translate-y-1 transition-all duration-300"
+        >
+          <div class="flex flex-col items-center">
+            <img
+              ngSrc="/images/icons/linkedin.svg"
+              alt="LinkedIn"
+              class="w-12 h-12 mb-4 invert-0 dark:invert drop-shadow-[0_0_1px_theme(colors.text)] dark:drop-shadow-none"
+              width="48"
+              height="48"
+            />
+            <span class="text-3xl font-bold text-tertiary mb-2">{{ counters().linkedin }}</span>
+            <span class="text-text text-sm">Visites LinkedIn</span>
+          </div>
+        </div>
       </div>
     </div>
   `,

--- a/src/app/admin/stats/counters/counters.smart.component.ts
+++ b/src/app/admin/stats/counters/counters.smart.component.ts
@@ -4,7 +4,20 @@ import { CountersService } from './services/counters.service';
 
 @Component({
   imports: [CountersDumbComponent],
-  template: ` <app-counters-dumb [counters]="countersService.getAllCounters()" /> `
+  template: `
+    <app-counters-dumb
+      [counters]="
+        countersService.getAllCounters() || {
+          calls: 0,
+          cv: 0,
+          github: 0,
+          linkedin: 0,
+          projects: 0,
+          websites: 0
+        }
+      "
+    />
+  `
 })
 export class CountersSmartComponent {
   protected readonly countersService = inject(CountersService);


### PR DESCRIPTION
- Intégrer un nouveau bloc de compteur pour les visites LinkedIn dans le composant dumb
- Ajouter une gestion par défaut des compteurs dans le composant smart
- Implémenter une méthode de sauvegarde des compteurs dans le service avec gestion des erreurs